### PR TITLE
Add CentOS CI build script and Dockerfiles

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,51 @@
+#Heavily inspired by https://github.com/fabric8io/fabric8-planner/blob/master/Dockerfile.builder
+
+FROM centos:7
+MAINTAINER Vasek Pavlin <vasek@redhat.com>
+ENV LANG=en_US.utf8
+
+VOLUME ['/dist']
+CMD ['/usr/bin/bash']
+
+#ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.9.2
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+  done
+
+RUN yum install -y wget bzip2 git nmap-ncat psmisc \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && yum remove -y wget \
+  && yum clean all
+
+ENV USER_NAME=forge
+
+RUN useradd --user-group --create-home --shell /bin/false ${USER_NAME}
+ENV HOME=/home/${USER_NAME}
+
+COPY . $HOME
+
+RUN chown -R ${USER_NAME}:${USER_NAME} $HOME/*
+
+USER ${USER_NAME}
+WORKDIR $HOME/

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,18 @@
+#Heavily inspired by https://github.com/fabric8io/fabric8-planner/blob/master/Dockerfile.deploy
+
+FROM registry.centos.org/kbsingh/openshift-nginx:latest
+MAINTAINER Vasek Pavlin <vasek@redhat.com>
+
+ENV LANG=en_US.utf8
+ENTRYPOINT /usr/bin/entrypoint.sh
+
+USER root
+ADD nginx.conf /etc/nginx/nginx.conf
+
+COPY scripts/entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+USER 997
+
+RUN rm /usr/share/nginx/html/*
+
+COPY dist /usr/share/nginx/html

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/bash
+
+
+REGISTRY_URI="registry.ci.centos.org:5000"
+REGISTRY_NS="obsidian"
+REGISTRY_IMAGE="obsidian-frontend:latest"
+RESITRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+BUILDER_IMAGE="obsidian-frontend-builder"
+BUILDER_CONT="obsidian-frontend-builder-container"
+DEPLOY_IMAGE="obsidian-frontend-deploy"
+
+TARGET_DIR="dist"
+
+# Show command before executing
+set -x
+
+# Exit on error
+set -e
+
+if [ -z $CICO_LOCAL ]; then
+    # We need to disable selinux for now, XXX
+    /usr/sbin/setenforce 0
+
+    # Get all the deps in
+    yum -y install docker make git
+
+    # Get all the deps in
+    yum -y install docker make git
+    sed -i '/OPTIONS=.*/c\OPTIONS="--selinux-enabled --log-driver=journald --insecure-registry '${REGISTRY_URI}'"' /etc/sysconfig/docker
+    service docker start
+fi
+
+#CLEAN
+docker ps | grep -q ${BUILDER_CONT} && docker stop ${BUILDER_CONT}
+docker ps -a | grep -q ${BUILDER_CONT} && docker rm ${BUILDER_CONT}
+rm -rf ${TARGET_DIR}/
+
+#BUILD
+docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
+
+mkdir ${TARGET_DIR}/
+docker run --detach=true --name ${BUILDER_CONT} -t -v $(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE} /bin/tail -f /dev/null #FIXME
+
+docker exec ${BUILDER_CONT} npm install
+docker exec ${BUILDER_CONT} npm run build:prod
+docker exec -u root ${BUILDER_CONT} cp -r ${TARGET_DIR}/* /
+
+#BUILD DEPLOY IMAGE
+docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .
+
+#PUSH
+if [ -z $CICO_LOCAL ]; then
+    docker tag ${DEPLOY_IMAGE} ${REGISTRY_URL}
+    docker push ${REGISTRY_URL}
+fi

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,7 +4,8 @@
 REGISTRY_URI="registry.ci.centos.org:5000"
 REGISTRY_NS="obsidian"
 REGISTRY_IMAGE="obsidian-frontend:latest"
-RESITRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+REGISTRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+REGISTRY_URL2="8.43.84.245.xip.io/${REGISTRY_NS}/${REGISTRY_IMAGE}"
 BUILDER_IMAGE="obsidian-frontend-builder"
 BUILDER_CONT="obsidian-frontend-builder-container"
 DEPLOY_IMAGE="obsidian-frontend-deploy"
@@ -52,4 +53,7 @@ docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .
 if [ -z $CICO_LOCAL ]; then
     docker tag ${DEPLOY_IMAGE} ${REGISTRY_URL}
     docker push ${REGISTRY_URL}
+
+    docker tag ${DEPLOY_IMAGE} ${REGISTRY_URL2}
+    docker push ${REGISTRY_URL2}
 fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,72 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+
+worker_processes 1;
+error_log /dev/stdout info;
+pid /run/nginx.pid;
+daemon off;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log 		/dev/stdout main;
+    client_body_temp_path /tmp;
+    fastcgi_temp_path /tmp;
+    scgi_temp_path /tmp;
+    proxy_temp_path /tmp;
+    uwsgi_temp_path /tmp;
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+        }
+
+        # This is added to support pushState URL patterm
+        # Redirecting every 404 to angular APP and 
+        # let the APP handle
+        error_page 404 =200 /index.html;
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+
+        gzip            on;
+        gzip_min_length 1000;
+        gzip_comp_level 9;
+        gzip_proxied    expired no-cache no-store private auth;
+        gzip_types      text/plain text/css application/javascript application/xml;
+    }
+
+# Settings for a TLS enabled server.
+# - we dont do TLS here, offload that to the openshift edge instead
+
+}
+

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+SETTINGS="/usr/share/nginx/html/settings.json"
+
+if [ -n "${OBSIDIAN_BACKEND_SERVICE_HOST}" ]; then
+   BACKEND_URI="http://${OBSIDIAN_BACKEND_SERVICE_HOST}:${OBSIDIAN_BACKEND_SERVICE_PORT}/"
+fi
+
+if [ -n "${BACKEND_URI}" ]; then
+    sed -i.bckp 's#"backend_url": ".*"#"backend_url": "'${BACKEND_URI}'"#' ${SETTINGS}
+fi
+
+exec /run.sh


### PR DESCRIPTION
This PR let's us build generator-frontend in CentOS CI (once we add it to https://github.com/almighty/almighty-jobs/blob/master/devtools-ci-index.yaml)

Right now it pushes only to registry.ci.centos.org, Docker Hub can/will be added later.