### PR TITLE
Remove default OpenSHift env var

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,10 +2,6 @@
 
 SETTINGS="/usr/share/nginx/html/settings.json"
 
-if [ -n "${OBSIDIAN_BACKEND_SERVICE_HOST}" ]; then
-   BACKEND_URI="http://${OBSIDIAN_BACKEND_SERVICE_HOST}:${OBSIDIAN_BACKEND_SERVICE_PORT}/"
-fi
-
 if [ -n "${BACKEND_URI}" ]; then
     sed -i.bckp 's#"backend_url": ".*"#"backend_url": "'${BACKEND_URI}'"#' ${SETTINGS}
 fi


### PR DESCRIPTION
This is not useful as frontend needs external URL for backend anyway.